### PR TITLE
More robust test using Storage fake

### DIFF
--- a/app/Http/Middleware/RequestLogger.php
+++ b/app/Http/Middleware/RequestLogger.php
@@ -3,10 +3,11 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Facades\Storage;
 
 class RequestLogger
 {
-    const LOG_FILEPATH = "storage/logs/requests.log";
+    const LOGFILE = "requests.log";
     /**
      * Handle an incoming request.
      *
@@ -16,16 +17,13 @@ class RequestLogger
      */
     public function handle($request, Closure $next)
     {
-        $filepath = base_path(self::LOG_FILEPATH);
-
-        $log_message = "Request: ".sprintf(
-            '%s %s %s',
+        $log_message = vsprintf('Request: %s %s %s', [
             $request->getMethod(),
             $request->getRequestUri(),
             json_encode($request->all())
-        )."\n";
+        ]);
 
-        file_put_contents($filepath, $log_message, FILE_APPEND);
+        Storage::disk('log')->append(self::LOGFILE, $log_message);
 
         return $next($request);
     }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -42,6 +42,10 @@ return [
     */
 
     'disks' => [
+        'log' => [
+            'driver' => 'local',
+            'root' => storage_path('logs'),
+        ],
 
         'local' => [
             'driver' => 'local',

--- a/tests/Unit/App/Http/Middleware/RequestLoggerTest.php
+++ b/tests/Unit/App/Http/Middleware/RequestLoggerTest.php
@@ -1,13 +1,16 @@
 <?php namespace Tests\Unit\App\Http\Middleware;
 
-use App\Http\Middleware\RequestLogger;
-use Illuminate\Http\Request;
 use Tests\TestCase;
+use Illuminate\Http\Request;
+use App\Http\Middleware\RequestLogger;
+use Illuminate\Support\Facades\Storage;
 
 class RequestLoggerTest extends TestCase
 {
     public function test_log_requests_to_file()
     {
+        Storage::fake('log');
+
         $logger_middleware = new RequestLogger();
 
         $uri = '/uri.php?val=1';
@@ -16,16 +19,10 @@ class RequestLoggerTest extends TestCase
         $request = Request::create($uri, $method, $data);
 
         $logger_middleware->handle($request, function(){});
-        $actual = $this->getLastLineOfLogFile();
 
-        $expected = "Request: $method $uri {\"key\":\"value\",\"val\":\"1\"}\n";
-
+        Storage::disk('log')->assertExists(RequestLogger::LOGFILE);
+        $actual = Storage::disk('log')->get(RequestLogger::LOGFILE);
+        $expected = "Request: $method $uri {\"key\":\"value\",\"val\":\"1\"}";
         $this->assertEquals($expected, $actual);
-    }
-
-    private function getLastLineOfLogFile()
-    {
-        $log_filepath = base_path(RequestLogger::LOG_FILEPATH);
-        return `tail -n 1 $log_filepath`;
     }
 }


### PR DESCRIPTION
I think this is a more robust test since the original was using the real file system and was reading the last line of the `requests.log` without knowing if the current test actually wrote that last line. The Storage fake will clean up before writing to the log, so the only line (if there is any) will be from the current test example.